### PR TITLE
fix: Set default mode and context for MetaBox blocks compatibility

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -15,6 +15,12 @@ class Block extends Metabox
      * The block type.
      */
     protected string $type = 'block';
+
+    /**
+     * The context of the block (override parent default).
+     */
+    protected string $context = 'normal';
+
     /**
      * The block title.
      */
@@ -68,7 +74,7 @@ class Block extends Metabox
     /**
      * The default mode of the block.
      */
-    protected string $mode;
+    protected string $mode = 'edit';
 
     /**
      * The render callback for the block.


### PR DESCRIPTION
## 📝 Description
```markdown
## Changes
- Set default `mode = 'edit'` for Block class
- Set default `context = 'normal'` for Block class

## Problem Solved
Fixes compatibility issues with recent MetaBox updates where:
- Blocks were stuck in preview mode by default
- Block fields were forced to display in sidebar instead of main content area
- Edit/preview mode toggle was not working properly

## Result
- Blocks now open in edit mode by default (better UX)
- Block fields display in the main content area instead of sidebar
- Users can still override these defaults when needed

## Backward Compatibility
✅ Fully backward compatible - existing blocks continue to work
✅ Values can still be overridden using `->mode()` and `->context()` methods
```

Cette description explique clairement le problème résolu et les bénéfices sans entrer dans les détails techniques complexes.